### PR TITLE
add support server-side hyperscript support

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -57,6 +57,7 @@ function handleValue (value) {
   if (value.__encoded) return value
 
   if (typeof value === 'object') {
+    if (typeof value.outerHTML === 'string') return value.outerHTML
     return Object.keys(value).reduce(function (str, key, i) {
       if (str.length > 0) str += ' '
 


### PR DESCRIPTION
Hello! 👋 

I'd very much like to help encourage interoperability between the `bel`/`nanohtml` and `hyperscript` ecosystems. In the browser, there are no issues, but in a node environment, some implementation details between `pelo`/`nanohtml/lib/server.js` and [`create-element`](https://github.com/1N50MN14/html-element) make things a little trickier.

When trying to render a hyperscript element inside of a nanohtml statement, I get the following error:

```
$ node example.js
/Users/ng/dev/modules/hyperaxe/node_modules/nanohtml/lib/server.js:61
    return Object.keys(value).reduce(function (str, key, i) {
                              ^

RangeError: Maximum call stack size exceeded
    at Array.reduce (<anonymous>)
    at handleValue (/Users/ng/dev/modules/hyperaxe/node_modules/nanohtml/lib/server.js:61:31)
    at /Users/ng/dev/modules/hyperaxe/node_modules/nanohtml/lib/server.js:71:21
    at Array.reduce (<anonymous>)
    at handleValue (/Users/ng/dev/modules/hyperaxe/node_modules/nanohtml/lib/server.js:61:31)
    at /Users/ng/dev/modules/hyperaxe/node_modules/nanohtml/lib/server.js:71:21
    at Array.reduce (<anonymous>)
    at handleValue (/Users/ng/dev/modules/hyperaxe/node_modules/nanohtml/lib/server.js:61:31)
    at /Users/ng/dev/modules/hyperaxe/node_modules/nanohtml/lib/server.js:71:21
    at Array.reduce (<anonymous>)
```

With the addition of a single line check for an `outerHTML` property, the issue is resolved.

```
$ node example.js

    <body>
     <h1>count is 0</h1>
     <button>Increment</button>
    </body>
```

Would maintainers be open to including this line in `nanohtml` for the sake of interoperability?